### PR TITLE
chore: add pr-author input

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,3 +23,4 @@ jobs:
         uses: guardian/post-release-action@main
         with:
           github-token: ${{ secrets.CI_TOKEN }}
+          pr-author: jamie-lynch


### PR DESCRIPTION
## What does this change?

This PR adds the `pr-author` value to the configuration as the default value is not set to `guardian-ci`