### PR TITLE
Use new action name

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -23,7 +23,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: ./script/cd
       - name: Post-release
-        uses: guardian/post-release-action@main
+        uses: guardian/actions-merge-release-changes-to-protected-branch@main
         with:
           github-token: ${{ secrets.CI_TOKEN_2 }}
           pr-author: jamie-lynch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     needs: [ci]
     steps:
       - name: Validate, approve and merge release PRs
-        uses: guardian/post-release-action@main
+        uses: guardian/actions-merge-release-changes-to-protected-branch@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-author: jamie-lynch


### PR DESCRIPTION
## What does this change?

As of https://github.com/guardian/actions-merge-release-changes-to-protected-branch/pull/6, the release action has a new name. This PR updates the name in the workflow files.

## How to test

Merge a change to main and see that the workflow runs as expcected.

## How can we measure success?

CI/CD continues to work as expected
