### PR TITLE
Use built in caching from setup-node action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -12,7 +12,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: guardian/actions-setup-node@main
-      - uses: bahmutov/npm-install@v1
+        with:
+          cache: "yarn"
+      - ryb: yarn install --frozen-lockfile
       - name: CD
         env:
           GITHUB_TOKEN: ${{ secrets.CI_TOKEN_2 }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: guardian/actions-setup-node@main
-      - uses: bahmutov/npm-install@v1
+        with:
+          cache: "yarn"
+      - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn build
   approveAndMerge:


### PR DESCRIPTION
## What does this change?

This change updates the _ci_ workflow to use caching implemented by [guardian/actions-setup-node](https://github.com/guardian/actions-setup-node) now that it's available. It also swaps out [bahmutov/npm-install](https://github.com/bahmutov/npm-install) for `yarn install --frozen-lockfile` as we no longer need the caching implemented by that action.